### PR TITLE
Fix export message in pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,8 +6,8 @@ logpath=".gitpsoft/logs"
 branch=$(git branch | grep '*' | sed 's/* //') 
 PS_PROJ_DB="$branch"
 exec < /dev/tty
-read -p "Import projects into '$branch'? " import
-if [[ $import =~ ^[Nn]$ ]]; then
+read -p "Export projects to '$branch' branch? " exportconfirm
+if [[ $exportconfirm =~ ^[Nn]$ ]]; then
 	exit
 fi
 if [ -z "$PS_PROJ_USER" ]; then


### PR DESCRIPTION
The `pre-commit` hook was using "Import" instead of "Export" in the user message. Updated the message and the variable name in the file.